### PR TITLE
switch to fs-extra

### DIFF
--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let fs = require('mz/fs');
+let fs = require('fs-extra');
 let Bluebird = require('bluebird');
 let mktmpdir = Bluebird.promisify(require("mktmpdir"));
 let archiver = require('archiver');
@@ -17,7 +17,7 @@ function deployCommand(context, heroku) {
   mktmpdir().spread(function(tmpDir, done) {
     paths.tar = `${tmpDir}/source.tar.gz`;
 
-    return fs.readFile(config.configFile).then(JSON.parse);
+    return fs.readJSON(config.configFile);
   }).then(function(config) {
     paths.root = config.root || ROOT_DEFAULT;
 

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "axios": "^0.5.4",
     "bluebird": "^2.9.34",
     "co": "^4.6.0",
+    "fs-extra": "^6.0.1",
     "heroku-cli-util": "5.2.1",
     "inquirer": "0.8.5",
     "json-stringify-safe": "5.0.1",
     "mktmpdir": "0.1.1",
-    "mz": "^2.0.0",
     "request": "2.58.0",
     "request-promise": "^0.4.2"
   }


### PR DESCRIPTION
mz is using the library thenify-all which emits a warning in node 10

I wasn't able to test this, but I've used `fs-extra` a lot and am pretty sure it should be the same.