### PR TITLE
Upload `.htpasswd`

### DIFF
--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -26,7 +26,7 @@ function deployCommand(context, heroku) {
     archive.on('finish', upload.bind(null, heroku, context, paths))
     archive.pipe(fs.createWriteStream(paths.tar))
     archive.bulk([{
-      src: ['static.json', `${paths.root}/**`],
+      src: ['static.json', '.htpasswd',`${paths.root}/**`],
       expand: true,
       dot: true,
       dest: false,


### PR DESCRIPTION
Because https://github.com/heroku/heroku-buildpack-static/pull/45 looks for `/app/.htpasswd` when:
- `"basic_auth": true` (`static.json`), and
- `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` are not set